### PR TITLE
Some fixes for --update

### DIFF
--- a/beanprice/price.py
+++ b/beanprice/price.py
@@ -384,15 +384,15 @@ def get_price_jobs_up_to_date(entries,
 
     if inactive:
         for base_quote in currencies:
-            if lifetimes_map[base_quote] is None:
+            if lifetimes_map[base_quote]:
+                # Use first date from lifetime
+                lifetimes_map[base_quote] = [(lifetimes_map[base_quote][0][0], None)]
+            else:
                 # Insert never active commodities into lifetimes
                 # Start from date of currency directive
                 base, _ = base_quote
                 commodity_entry = commodity_map.get(base, None)
                 lifetimes_map[base_quote] = [(commodity_entry.date, None)]
-            else:
-                # Use first date from lifetime
-                lifetimes_map[base_quote] = [(lifetimes_map[base_quote][0][0], None)]
     else:
         #Compress any lifetimes based on compress_days
         lifetimes_map = lifetimes.compress_lifetimes_days(lifetimes_map, compress_days)

--- a/beanprice/price.py
+++ b/beanprice/price.py
@@ -413,6 +413,13 @@ def get_price_jobs_up_to_date(entries,
                                          latest_price_date + datetime.timedelta(days=1),
                                          date_last)
 
+    # Remove currency pairs we can't fetch any prices for.
+    if not default_source:
+        keys = list(lifetimes_map.keys())
+        for key in keys:
+            if not currency_map.get(key, None):
+                del lifetimes_map[key]
+
     # Create price jobs based on fetch rate
     if update_rate == 'daily':
         required_prices = lifetimes.required_daily_prices(

--- a/beanprice/price.py
+++ b/beanprice/price.py
@@ -408,10 +408,15 @@ def get_price_jobs_up_to_date(entries,
                                          date_last)
         else:
             latest_price_date = result[0]
-            lifetimes_map[base_quote] = \
-                lifetimes.trim_intervals(intervals,
-                                         latest_price_date + datetime.timedelta(days=1),
-                                         date_last)
+            date_first = latest_price_date + datetime.timedelta(days=1)
+            if date_first < date_last:
+                lifetimes_map[base_quote] = \
+                    lifetimes.trim_intervals(intervals,
+                                            date_first,
+                                            date_last)
+            else:
+                # We don't need to update if we're already up to date.
+                lifetimes_map[base_quote] = []
 
     # Remove currency pairs we can't fetch any prices for.
     if not default_source:


### PR DESCRIPTION
I noticed some exceptions while trying to use `--update`. These two commits seem to resolve these issues for now:

1. As `beancount.ops.lifetimes.get_commodity_lifetimes` returns empty lists for commodities without lifetimes (instead of simply returning `None`), `get_price_jobs_up_to_date` was trying to index into an empty list. We can resolve this by checking whether the list of lifetimes in truthy (instead of just checking for `None`).
2. If there is no default source, it doesn't make sense to try and create jobs with a `None` source for an unknown currency pair, because trying to run (or even report to the output about) such a job will inevitably fail. I opted for not even calculating the `required_daily_prices` for these pairs, since the start of the commodity's lifetime may be far in the past.
3. If there is already a price newer than the end date of the update (e,g, we're trying to update for the second time today), trimming the lifetime intervals results in a `ValueError`, because the start of the time window is later than the end. Avoid trimming and updating altogether in this case.