### PR TITLE
Raise YahooError when no data is returned.

### DIFF
--- a/beanprice/sources/yahoo.py
+++ b/beanprice/sources/yahoo.py
@@ -25,7 +25,6 @@ import requests
 
 from beanprice import source
 
-
 class YahooError(ValueError):
     "An error from the Yahoo API."
 
@@ -89,6 +88,10 @@ def get_price_series(ticker: str,
     meta = result['meta']
     tzone = timezone(timedelta(hours=meta['gmtoffset'] / 3600),
                      meta['exchangeTimezoneName'])
+
+    if 'timestamp' not in result:
+        raise YahooError("Yahoo returned no data for ticker {} for time range {} - {}".format(
+            ticker, time_begin, time_end))
 
     timestamp_array = result['timestamp']
     close_array = result['indicators']['quote'][0]['close']

--- a/beanprice/sources/yahoo_test.py
+++ b/beanprice/sources/yahoo_test.py
@@ -154,6 +154,41 @@ class YahooFinancePriceFetcher(unittest.TestCase):
         with self.assertRaises(yahoo.YahooError):
             yahoo.parse_response(response)
 
+    def test_parse_response_no_timestamp(self):
+        response = MockResponse(textwrap.dedent("""
+            {"chart":
+             {"error": null,
+              "result": [{"indicators": {"adjclose": [{}],
+                                         "quote": [{}]},
+                          "meta": {"chartPreviousClose": 29.25,
+                                   "currency": "CAD",
+                                   "currentTradingPeriod": {"post": {"end": 1522702800,
+                                                                     "gmtoffset": -14400,
+                                                                     "start": 1522699200,
+                                                                     "timezone": "EDT"},
+                                                            "pre": {"end": 1522675800,
+                                                                    "gmtoffset": -14400,
+                                                                    "start": 1522670400,
+                                                                    "timezone": "EDT"},
+                                                            "regular": {"end": 1522699200,
+                                                                        "gmtoffset": -14400,
+                                                                        "start": 1522675800,
+                                                                        "timezone": "EDT"}},
+                                   "dataGranularity": "1d",
+                                   "exchangeName": "TOR",
+                                   "exchangeTimezoneName": "America/Toronto",
+                                   "firstTradeDate": 1018872000,
+                                   "gmtoffset": -14400,
+                                   "instrumentType": "ETF",
+                                   "symbol": "XSP.TO",
+                                   "timezone": "EDT",
+                                   "validRanges": ["1d", "5d", "1mo", "3mo", "6mo", "1y",
+                                                   "2y", "5y", "10y", "ytd", "max"]}}]}}"""))
+        with self.assertRaises(yahoo.YahooError):
+            with mock.patch('requests.get', return_value=response):
+                srcprice = yahoo.Source().get_historical_price(
+                    'XSP.TO', datetime.datetime(2017, 11, 1, 16, 0, 0, tzinfo=tz.tzutc()))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Before this change, the code was raising an exception at getting the
'timestamp' field from the result dict, because this field is not
populated in such use case.