### PR TITLE
Run mypy automatically as part of CI.

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,3 +16,4 @@ jobs:
       - run: pip install -r requirements_dev.txt
       - run: pylint beanprice
       - run: pytest beanprice
+      - run: mypy beanprice --ignore-missing-imports

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 pylint==2.7.2
 pytest==5.4.2
+mypy==0.812


### PR DESCRIPTION
I am ignoring imports because the beancount stubs are not available.
Fava has its own 'stubs' directory for beancount, we could do something
similar in the followup, or create some generic solution that would work
for all repositories using beancount.

Refs #31