### PR TITLE
Rename github action from python to beancount-v2.

### DIFF
--- a/.github/workflows/beancount-v2.yml
+++ b/.github/workflows/beancount-v2.yml
@@ -1,4 +1,4 @@
-name: python
+name: beancount-v2
 
 on:
   [push, pull_request]


### PR DESCRIPTION
I believe it will make it cleaner, when the CI runs on a PR, that we
have workflow for beancount-v2 and beancount-v3.