### PR TITLE
Improve error message returned for invalid ticker.

### DIFF
--- a/beanprice/sources/yahoo.py
+++ b/beanprice/sources/yahoo.py
@@ -44,6 +44,8 @@ def parse_response(response: requests.models.Response) -> Dict:
             ','.join(json.keys())))
     if content['error'] is not None:
         raise YahooError("Error fetching Yahoo data: {}".format(content['error']))
+    if not content['result']:
+        raise YahooError("No data returned from Yahoo, ensure that the symbol is correct")
     return content['result'][0]
 
 

--- a/beanprice/sources/yahoo_test.py
+++ b/beanprice/sources/yahoo_test.py
@@ -154,6 +154,12 @@ class YahooFinancePriceFetcher(unittest.TestCase):
         with self.assertRaises(yahoo.YahooError):
             yahoo.parse_response(response)
 
+    def test_parse_response_empty_result(self):
+        response = MockResponse(
+            '{"quoteResponse": {"error": null, "result": []}}')
+        with self.assertRaises(yahoo.YahooError):
+            yahoo.parse_response(response)
+
     def test_parse_response_no_timestamp(self):
         response = MockResponse(textwrap.dedent("""
             {"chart":


### PR DESCRIPTION
When ticker is invalid, the `result` field in the response is empty.
Instead of raising error that we are accessing element 0 of empty list,
return YahooError explaining that no data was returned, probably because
used symbol is invalid.

Fixes #23 #39