### PR TITLE
Add coincap source

### DIFF
--- a/beanprice/sources/BUILD
+++ b/beanprice/sources/BUILD
@@ -98,3 +98,21 @@ py_test(
         "//beancount/prices/sources:tsp",
     ],
 )
+
+py_library(
+    name = "coincap",
+    srcs = ["coincap.py"],
+    deps = [
+        "//beancount/core:number",
+        "//beancount/prices:source",
+    ],
+)
+
+py_test(
+    name = "coincap_test",
+    srcs = ["coincap_test.py"],
+    deps = [
+        "//beancount/core:number",
+        "//beancount/prices/sources:tsp",
+    ],
+)

--- a/beanprice/sources/coincap.py
+++ b/beanprice/sources/coincap.py
@@ -1,0 +1,125 @@
+"""
+A source fetching cryptocurrency prices from Coincap.
+
+Tickers can be in two formats: Either using the coincap currency id (bitcoin,
+ethereum, etc.), or using a currency ticker (BTC, ETH, etc.). In the latter
+case, any ambiguity will be resolved using the coin ranking.
+
+Prices are denoted in USD.
+
+The documentation can be found here:
+https://docs.coincap.io/
+
+"""
+
+import datetime
+import math
+from decimal import Decimal
+from typing import List, Optional, Tuple, Dict
+import requests
+from beanprice import source
+
+API_BASE_URL = 'https://api.coincap.io/v2/'
+
+
+class CoincapError(ValueError):
+    "An error from the Coincap importer."
+
+
+def get_asset_list() -> List[Dict[str, str]]:
+    """
+    Get list of currencies supported by Coincap. Returned is a list with
+    elements with many properties, including "id", representing the Coincap id,
+    and "symbol", representing the ticker symbol.
+    """
+    path = 'assets/'
+    url = API_BASE_URL + path
+    response = requests.get(url)
+    data = response.json()['data']
+    return data
+
+
+def get_currency_id(currency: str) -> Optional[str]:
+    """
+    Find currency ID by its symbol.
+    If results are ambiguous, select currency with the highest market cap
+    """
+    # Array is already sorted based on market cap
+    for coin in get_asset_list():
+        if coin['symbol'] == currency:
+            return coin['id']
+    return None
+
+
+def resolve_currency_id(base_currency: str) -> str:
+    """
+    Obtain the currency ID from the ticker, which can either already be a
+    currency id (bitcoin), or a coin ticker (BTC).
+    """
+    if base_currency.isupper():
+        # Try to find currency ID by its symbol
+        base_currency_id = get_currency_id(base_currency)
+        if not isinstance(base_currency_id, str):
+            raise CoincapError("Could not find currency id with ticker '"
+                               + base_currency + "'")
+        return base_currency_id
+    else:
+        return base_currency
+
+
+def get_latest_price(base_currency: str) -> Tuple[float, float]:
+    path = 'assets/'
+    url = API_BASE_URL + path + resolve_currency_id(base_currency)
+    response = requests.get(url)
+    data = response.json()
+    timestamp = data['timestamp'] / 1000.0
+    price_float = data['data']['priceUsd']
+    return price_float, timestamp
+
+
+def get_price_series(base_currency_id: str, time_begin: datetime.datetime,
+                     time_end: datetime.datetime) -> List[source.SourcePrice]:
+    path = 'assets/{}/history'.format(base_currency_id)
+    params = {
+        'interval': 'd1',
+        'start': str(math.floor(time_begin.timestamp() * 1000.0)),
+        'end': str(math.ceil(time_end.timestamp() * 1000.0))
+    }
+    url = API_BASE_URL + path
+    response = requests.get(url, params=params)
+    return [source.SourcePrice(
+        Decimal(item['priceUsd']),
+        datetime.datetime.fromtimestamp(
+            item['time'] / 1000.0).replace(tzinfo=datetime.timezone.utc),
+        'USD'
+    )
+        for item in response.json()['data']]
+
+
+class Source(source.Source):
+    """A price source for the Coincap API v2. Supports only prices denoted in USD.
+    There are two ways of expressing a ticker, either by their coincap id (bitcoin)
+    or by their ticker (BTC), in which case the highest ranked coin will be picked."""
+
+    def get_latest_price(self, ticker) -> source.SourcePrice:
+        price_float, timestamp = get_latest_price(ticker)
+        price = Decimal(price_float)
+        price_time = datetime.datetime.fromtimestamp(timestamp).\
+            replace(tzinfo=datetime.timezone.utc)
+        return source.SourcePrice(price, price_time, 'USD')
+
+    def get_historical_price(self, ticker: str,
+                             time: datetime.datetime) -> Optional[source.SourcePrice]:
+        for datapoint in self.get_prices_series(ticker,
+                                                time +
+                                                datetime.timedelta(days=-1),
+                                                time + datetime.timedelta(days=1)):
+            if not datapoint.time is None and datapoint.time.date() == time.date():
+                return datapoint
+        return None
+
+    def get_prices_series(self, ticker: str,
+                          time_begin: datetime.datetime,
+                          time_end: datetime.datetime
+                          ) -> List[source.SourcePrice]:
+        return get_price_series(resolve_currency_id(ticker), time_begin, time_end)

--- a/beanprice/sources/coincap_test.py
+++ b/beanprice/sources/coincap_test.py
@@ -1,0 +1,108 @@
+import datetime
+import unittest
+from decimal import Decimal
+
+from unittest import mock
+from dateutil import tz
+
+import requests
+
+from beanprice import source
+from beanprice.sources import coincap
+
+timezone = tz.gettz("Europe/Amsterdam")
+
+
+response_assets_bitcoin_historical = {"data": [{"priceUsd": "32263.2648195597839546",
+                                                "time": 1609804800000,
+                                                "date": "2021-01-05T00:00:00.000Z"},
+                                               {"priceUsd": "34869.7692419204775049",
+                                                "time": 1609891200000,
+                                                "date": "2021-01-06T00:00:00.000Z"}],
+                                      "timestamp": 1618220568799}
+
+response_assets_bitcoin = {"data":
+                           {"id": "bitcoin",
+                            "rank": "1",
+                            "symbol": "BTC",
+                            "name": "Bitcoin",
+                            "supply": "18672456.0000000000000000",
+                            "maxSupply": "21000000.0000000000000000",
+                            "marketCapUsd": "1134320211245.9295410753733840",
+                            "volumeUsd24Hr": "16998481452.4370929843940509",
+                            "priceUsd": "60748.3135183678858890",
+                            "changePercent24Hr": "1.3457951950518293",
+                            "vwap24Hr": "59970.0332730340881967",
+                            "explorer": "https://blockchain.info/"
+                            }, "timestamp": 1618218375359}
+
+response_bitcoin_history = {"data":
+                            [{"priceUsd": "29232.6707650537687673",
+                              "time": 1609459200000,
+                              "date": "2021-01-01T00:00:00.000Z"},
+                             {"priceUsd": "30688.0967118388768791",
+                              "time": 1609545600000,
+                              "date": "2021-01-02T00:00:00.000Z"},
+                                {"priceUsd": "33373.7277104175704785",
+                                 "time": 1609632000000,
+                                 "date": "2021-01-03T00:00:00.000Z"},
+                                {"priceUsd": "31832.6862288485383625",
+                                 "time": 1609718400000, "date": "2021-01-04T00:00:00.000Z"},
+                                {"priceUsd": "32263.2648195597839546",
+                                 "time": 1609804800000, "date": "2021-01-05T00:00:00.000Z"},
+                                {"priceUsd": "34869.7692419204775049",
+                                 "time": 1609891200000, "date": "2021-01-06T00:00:00.000Z"},
+                                {"priceUsd": "38041.0026368820979411",
+                                 "time": 1609977600000, "date": "2021-01-07T00:00:00.000Z"},
+                                {"priceUsd": "39821.5432664411153366",
+                                 "time": 1610064000000,
+                                 "date": "2021-01-08T00:00:00.000Z"}
+                             ], "timestamp": 1618219315479}
+
+
+def response(content, status_code=requests.codes.ok):
+    """Return a context manager to patch a JSON response."""
+    response = mock.Mock()
+    response.status_code = status_code
+    response.text = ""
+    response.json.return_value = content
+    return mock.patch('requests.get', return_value=response)
+
+
+class Source(unittest.TestCase):
+    def test_get_latest_price(self):
+        with response(content=response_assets_bitcoin):
+            srcprice = coincap.Source().get_latest_price('bitcoin')
+            self.assertIsInstance(srcprice, source.SourcePrice)
+            self.assertEqual(Decimal('60748.3135183678858890'), srcprice.price)
+            self.assertEqual(datetime.datetime(2021, 4, 12)
+                             .replace(tzinfo=datetime.timezone.utc).date(),
+                             srcprice.time.date())
+            self.assertEqual('USD', srcprice.quote_currency)
+
+    def test_get_historical_price(self):
+        with response(content=response_assets_bitcoin_historical):
+            srcprice = coincap.Source().get_historical_price(
+                'bitcoin', datetime.datetime(2021, 1, 6))
+            self.assertEqual(Decimal('34869.7692419204775049'), srcprice.price)
+            self.assertEqual(datetime.datetime(2021, 1, 6)
+                             .replace(tzinfo=datetime.timezone.utc).date(),
+                             srcprice.time.date())
+            self.assertEqual('USD', srcprice.quote_currency)
+
+    def test_get_prices_series(self):
+        with response(content=response_bitcoin_history):
+            srcprices = coincap.Source().get_prices_series(
+                'bitcoin', datetime.datetime(2021, 1, 1),
+                datetime.datetime(2021, 3, 20))
+            self.assertEqual(len(srcprices), 8)
+            self.assertEqual(Decimal('29232.6707650537687673'),
+                             srcprices[0].price)
+            self.assertEqual(datetime.datetime(2021, 1, 1)
+                             .replace(tzinfo=datetime.timezone.utc).date(),
+                             srcprices[0].time.date())
+            self.assertEqual('USD', srcprices[0].quote_currency)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This adds a source for the Coincap cryptocurrency API. It doesn't require an API key but only supports prices denoted USD.