### PR TITLE
use a different host for ratesapi

### DIFF
--- a/beanprice/sources/ratesapi.py
+++ b/beanprice/sources/ratesapi.py
@@ -1,13 +1,13 @@
-"""A source fetching exchangerates from https://ratesapi.io.
+"""A source fetching exchangerates from https://exchangerate.host.
 
 Valid tickers are in the form "XXX-YYY", such as "EUR-CHF".
 
 Here is the API documentation:
-https://ratesapi.io/documentation/
+https://exchangerate.host/
 
 For example:
 
-https://api.ratesapi.io/api/latest?base=EUR&symbols=CHF
+https://api.exchangerate.host/api/latest?base=EUR&symbols=CHF
 
 
 Timezone information: Input and output datetimes are specified via UTC
@@ -48,7 +48,7 @@ def _get_quote(ticker, date):
         'base': base,
         'symbol': symbol,
     }
-    response = requests.get(url='https://api.ratesapi.io/' + date, params=params)
+    response = requests.get(url='https://api.exchangerate.host/' + date, params=params)
 
     if response.status_code != requests.codes.ok:
         raise RatesApiError("Invalid response ({}): {}".format(response.status_code,


### PR DESCRIPTION
@blais can you merge this asap, unfortunately the previous host went offline, but this one provides the same api and seems to have been around for a longer time.

Fixes #53 