### PR TITLE
fix TypeError when no price is returned

### DIFF
--- a/beanprice/sources/yahoo.py
+++ b/beanprice/sources/yahoo.py
@@ -100,7 +100,7 @@ def get_price_series(ticker: str,
     timestamp_array = result['timestamp']
     close_array = result['indicators']['quote'][0]['close']
     series = [(datetime.fromtimestamp(timestamp, tz=tzone), Decimal(price))
-              for timestamp, price in zip(timestamp_array, close_array)]
+              for timestamp, price in zip(timestamp_array, close_array) if price is not None]
 
     currency = result['meta']['currency']
     return series, currency


### PR DESCRIPTION
Sometimes the yahoo source will return None as a price (I think due
to the date being too recent), this will result in a TypeError
"conversion from NoneType to Decimal is not supported" when
conversion of the price to a Decimal is attempted.

See #60 