### PR TITLE
Yahoo: Fix parsing when final price in series is null

### DIFF
--- a/beanprice/sources/yahoo.py
+++ b/beanprice/sources/yahoo.py
@@ -100,7 +100,8 @@ def get_price_series(ticker: str,
     timestamp_array = result['timestamp']
     close_array = result['indicators']['quote'][0]['close']
     series = [(datetime.fromtimestamp(timestamp, tz=tzone), Decimal(price))
-              for timestamp, price in zip(timestamp_array, close_array)]
+              for timestamp, price in zip(timestamp_array, close_array)
+              if price is not None]
 
     currency = result['meta']['currency']
     return series, currency


### PR DESCRIPTION
For a mutual fund for today, Yahoo API returns a null for the most recent price entry in the price array. A timestamps is present, but the price values are null:

e.g.:
```[9.6899995803833,9.710000038146973,9.6899995803833,null]```

The current code anticipates the response potentially returning a price earlier than the date queried, so this fix just filters out the null entries and returns what's left, even if earlier than the queried date.

e.g. from:
https://query1.finance.yahoo.com/v8/finance/chart/FTIHX?period1=1645650000&period2=1646082000&interval=1d&lang=en-US&corsDomain=finance.yahoo.com&.tsrc=finance


returns:

```json
{"chart":{"result":[{"meta":{"currency":"USD","symbol":"FTIHX","exchangeName":"NAS","instrumentType":"MUTUALFUND","firstTradeDate":1466083800,"regularMarketTime":1646053576,"gmtoffset":-18000,"timezone":"EST","exchangeTimezoneName":"America/New_York","regularMarketPrice":13.63,"chartPreviousClose":13.56,"priceHint":2,"currentTradingPeriod":{"pre":{"timezone":"EST","start":1646038800,"end":1646058600,"gmtoffset":-18000},"regular":{"timezone":"EST","start":1646058600,"end":1646082000,"gmtoffset":-18000},"post":{"timezone":"EST","start":1646082000,"end":1646096400,"gmtoffset":-18000}},"dataGranularity":"1d","range":"","validRanges":["1mo","3mo","6mo","ytd","1y","2y","5y","10y","max"]},
"timestamp":[1645626600,1645713000,1645799400,1646058600],
"indicators":{"quote":[{
"close":[13.5600004196167,13.34000015258789,13.630000114440918,null],
"low":[13.5600004196167,13.34000015258789,13.630000114440918,null],
"open":[13.5600004196167,13.34000015258789,13.630000114440918,null],
"high":[13.5600004196167,13.34000015258789,13.630000114440918,null]
,"volume":[0,0,0,null]}],"adjclose":[{"adjclose":[13.5600004196167,13.34000015258789,13.630000114440918,null]}]}}],"error":null}}
```