### PR TITLE
Switch to api.frankfurter.app for rates

### DIFF
--- a/beanprice/sources/ratesapi.py
+++ b/beanprice/sources/ratesapi.py
@@ -3,11 +3,11 @@
 Valid tickers are in the form "XXX-YYY", such as "EUR-CHF".
 
 Here is the API documentation:
-https://exchangerate.host/
+https://api.frankfurter.app/
 
 For example:
 
-https://api.exchangerate.host/api/latest?base=EUR&symbols=CHF
+https://api.frankfurter.app/latest?base=EUR&symbols=CHF
 
 
 Timezone information: Input and output datetimes are specified via UTC
@@ -48,7 +48,7 @@ def _get_quote(ticker, date):
         'base': base,
         'symbol': symbol,
     }
-    response = requests.get(url='https://api.exchangerate.host/' + date, params=params)
+    response = requests.get(url='https://api.frankfurter.app/' + date, params=params)
 
     if response.status_code != requests.codes.ok:
         raise RatesApiError("Invalid response ({}): {}".format(response.status_code,


### PR DESCRIPTION
exchangerate.host is no more available without api key, fixes #80 