### PR TITLE
Get yahoo price series only when price is not None

### DIFF
--- a/beanprice/sources/yahoo.py
+++ b/beanprice/sources/yahoo.py
@@ -100,7 +100,8 @@ def get_price_series(ticker: str,
     timestamp_array = result['timestamp']
     close_array = result['indicators']['quote'][0]['close']
     series = [(datetime.fromtimestamp(timestamp, tz=tzone), Decimal(price))
-              for timestamp, price in zip(timestamp_array, close_array)]
+              for timestamp, price in zip(timestamp_array, close_array)
+              if price is not None]
 
     currency = result['meta']['currency']
     return series, currency


### PR DESCRIPTION
When there is a bank holiday, no pricing data is available. In case of AAPL (https://finance.yahoo.com/quote/AAPL/history?p=AAPL, see 2023-07-04) timeseries returned by an API call simply skips this particular date. However, securities traded in Warsaw Stock Exchange (e. g. PKO.WA, https://finance.yahoo.com/quote/PKO.WA/history?p=PKO.WA, see 2023-11-01), return timeseries with None as a price for a timestamp of a bank holiday. This causes an exception to by thrown.

This PR simply filters out onle these timestamps with non-None price.