### PR TITLE
Fix fetching prices from yahoo

### DIFF
--- a/beanprice/sources/yahoo.py
+++ b/beanprice/sources/yahoo.py
@@ -115,7 +115,7 @@ class Source(source.Source):
 
         session = requests.Session()
         session.headers.update({'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/110.0'})
-        session.get('https://fc.yahoo.com')  # This populates the correct cookies in the session
+        session.get('https://guce.yahoo.com/consent')  # This populates the correct cookies in the session
         crumb = session.get('https://query1.finance.yahoo.com/v1/test/getcrumb').text
 
         url = "https://query1.finance.yahoo.com/v7/finance/quote"


### PR DESCRIPTION
It appears that https://fc.yahoo.com no longer works and returns and error `Failed to establish a new connection: [Errno 111] Connection refused`.

To resolve this, we can use a different yahoo domain that works as shown in this issue https://github.com/ranaroussi/yfinance/issues/1765.