### PR TITLE
Unify requests configuration

### DIFF
--- a/beanprice/sources/yahoo.py
+++ b/beanprice/sources/yahoo.py
@@ -134,7 +134,9 @@ class Source(source.Source):
         )
         # This populates the correct cookies in the session
         self.session.get("https://fc.yahoo.com")
-        self.crumb = self.session.get("https://query1.finance.yahoo.com/v1/test/getcrumb").text
+        self.crumb = self.session.get(
+            "https://query1.finance.yahoo.com/v1/test/getcrumb"
+        ).text
 
     def get_latest_price(self, ticker: str) -> Optional[source.SourcePrice]:
         """See contract in beanprice.source.Source."""
@@ -179,7 +181,9 @@ class Source(source.Source):
         """See contract in beanprice.source.Source."""
 
         # Get the latest data returned over the last 5 days.
-        series, currency = get_price_series(ticker, time - timedelta(days=5), time, self.session)
+        series, currency = get_price_series(
+            ticker, time - timedelta(days=5), time, self.session
+        )
         latest = None
         for data_dt, price in sorted(series):
             if data_dt >= time:

--- a/beanprice/sources/yahoo.py
+++ b/beanprice/sources/yahoo.py
@@ -77,7 +77,10 @@ _DEFAULT_PARAMS = {
 
 
 def get_price_series(
-    ticker: str, time_begin: datetime, time_end: datetime
+    ticker: str,
+    time_begin: datetime,
+    time_end: datetime,
+    session: requests.Session,
 ) -> Tuple[List[Tuple[datetime, Decimal]], str]:
     """Return a series of timestamped prices."""
 
@@ -90,7 +93,7 @@ def get_price_series(
         "interval": "1d",
     }
     payload.update(_DEFAULT_PARAMS)
-    response = requests.get(url, params=payload, headers={"User-Agent": None})
+    response = session.get(url, params=payload)  # Use shared session
     result = parse_response(response)
 
     meta = result["meta"]
@@ -120,19 +123,21 @@ def get_price_series(
 class Source(source.Source):
     "Yahoo Finance CSV API price extractor."
 
-    def get_latest_price(self, ticker: str) -> Optional[source.SourcePrice]:
-        """See contract in beanprice.source.Source."""
-
-        session = requests.Session()
-        session.headers.update(
+    def __init__(self):
+        """Initialize a shared session with the required headers and cookies."""
+        self.session = requests.Session()
+        self.session.headers.update(
             {
                 "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) "
                 "Gecko/20100101 Firefox/110.0"
             }
         )
         # This populates the correct cookies in the session
-        session.get("https://fc.yahoo.com")
-        crumb = session.get("https://query1.finance.yahoo.com/v1/test/getcrumb").text
+        self.session.get("https://fc.yahoo.com")
+        self.crumb = self.session.get("https://query1.finance.yahoo.com/v1/test/getcrumb").text
+
+    def get_latest_price(self, ticker: str) -> Optional[source.SourcePrice]:
+        """See contract in beanprice.source.Source."""
 
         url = "https://query1.finance.yahoo.com/v7/finance/quote"
         fields = ["symbol", "regularMarketPrice", "regularMarketTime"]
@@ -140,10 +145,11 @@ class Source(source.Source):
             "symbols": ticker,
             "fields": ",".join(fields),
             "exchange": "NYSE",
-            "crumb": crumb,
+            "crumb": self.crumb,  # Use the session’s crumb
         }
         payload.update(_DEFAULT_PARAMS)
-        response = session.get(url, params=payload)
+        response = self.session.get(url, params=payload)  # Use shared session
+
         try:
             result = parse_response(response)
         except YahooError as error:
@@ -173,7 +179,7 @@ class Source(source.Source):
         """See contract in beanprice.source.Source."""
 
         # Get the latest data returned over the last 5 days.
-        series, currency = get_price_series(ticker, time - timedelta(days=5), time)
+        series, currency = get_price_series(ticker, time - timedelta(days=5), time, self.session)
         latest = None
         for data_dt, price in sorted(series):
             if data_dt >= time:
@@ -188,5 +194,5 @@ class Source(source.Source):
         self, ticker: str, time_begin: datetime, time_end: datetime
     ) -> Optional[List[source.SourcePrice]]:
         """See contract in beanprice.source.Source."""
-        series, currency = get_price_series(ticker, time_begin, time_end)
+        series, currency = get_price_series(ticker, time_begin, time_end, self.session)
         return [source.SourcePrice(price, time, currency) for time, price in series]

--- a/beanprice/sources/yahoo_test.py
+++ b/beanprice/sources/yahoo_test.py
@@ -8,7 +8,6 @@ import unittest
 from decimal import Decimal
 from unittest import mock
 
-import pytest
 from dateutil import tz
 import requests
 

--- a/beanprice/sources/yahoo_test.py
+++ b/beanprice/sources/yahoo_test.py
@@ -51,8 +51,9 @@ class YahooFinancePriceFetcher(unittest.TestCase):
                           "tradeable": false}]}}
             """)
         )
-        with mock.patch("requests.get", return_value=response):
-            srcprice = yahoo.Source().get_latest_price("XSP.TO")
+        yahoo_source = yahoo.Source()
+        with mock.patch.object(yahoo_source.session, "get", return_value=response):
+            srcprice = yahoo_source.get_latest_price("XSP.TO")
         self.assertTrue(isinstance(srcprice.price, Decimal))
         self.assertEqual(Decimal("29.99"), srcprice.price)
         timezone = datetime.timezone(datetime.timedelta(hours=-4), "America/Toronto")
@@ -61,7 +62,6 @@ class YahooFinancePriceFetcher(unittest.TestCase):
         )
         self.assertEqual("CAD", srcprice.quote_currency)
 
-    @pytest.mark.skip(reason="The mock.patch() call is incorrect, has not been updated.")
     def test_get_latest_price(self):
         for tzname in "America/New_York", "Europe/Berlin", "Asia/Tokyo":
             with date_utils.intimezone(tzname):
@@ -125,8 +125,9 @@ class YahooFinancePriceFetcher(unittest.TestCase):
                                         1509456600,
                                         1509543000]}]}}""")
         )
-        with mock.patch("requests.get", return_value=response):
-            srcprice = yahoo.Source().get_historical_price(
+        yahoo_source = yahoo.Source()
+        with mock.patch.object(yahoo_source.session, "get", return_value=response):
+            srcprice = yahoo_source.get_historical_price(
                 "XSP.TO", datetime.datetime(2017, 11, 1, 16, 0, 0, tzinfo=tz.tzutc())
             )
         self.assertTrue(isinstance(srcprice.price, Decimal))
@@ -203,8 +204,9 @@ class YahooFinancePriceFetcher(unittest.TestCase):
         """)
         )
         with self.assertRaises(yahoo.YahooError):
-            with mock.patch("requests.get", return_value=response):
-                _ = yahoo.Source().get_historical_price(
+            yahoo_source = yahoo.Source()
+            with mock.patch.object(yahoo_source.session, "get", return_value=response):
+                _ = yahoo_source.get_historical_price(
                     "XSP.TO", datetime.datetime(2017, 11, 1, 16, 0, 0, tzinfo=tz.tzutc())
                 )
 
@@ -241,8 +243,9 @@ class YahooFinancePriceFetcher(unittest.TestCase):
         """)
         )
 
-        with mock.patch("requests.get", return_value=response):
-            srcprice = yahoo.Source().get_historical_price(
+        yahoo_source = yahoo.Source()
+        with mock.patch.object(yahoo_source.session, "get", return_value=response):
+            srcprice = yahoo_source.get_historical_price(
                 "XSP.TO", datetime.datetime(2022, 2, 28, 16, 0, 0, tzinfo=tz.tzutc())
             )
             self.assertTrue(isinstance(srcprice.price, Decimal))


### PR DESCRIPTION
This PR introduces fix for error with yahoo source that started recently.

### The error reproduce
Run in console:
`bean-price -d 2025-02-20 -e USD:yahoo/AAPL`
which fails with error, while the
`bean-price -e USD:yahoo/AAPL`
works successfully

### Root cause
User-Agent behavior is different for `beanprice.sources.yahoo.get_latest_price` which works, and `beanprice.sources.yahoo.get_historical_price`

### The changes
 - Unification of session initialization with `get_latest_price`-like configuration.
 - Unit tests adapted to the change
 - Fixed skipped `test_get_latest_price` unit test
 
 I have tried to provide minimal working solution in this PR, happy to adapt if more changes required.