### PR TITLE
Issue 106 and 107 resolved

### DIFF
--- a/beanprice/price.py
+++ b/beanprice/price.py
@@ -978,3 +978,6 @@ def main():
 
     # Print out the entries.
     printer.print_entries(price_entries, dcontext=dcontext)
+
+if __name__ == '__main__':
+    main()

--- a/beanprice/sources/yahoo.py
+++ b/beanprice/sources/yahoo.py
@@ -22,7 +22,7 @@ from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import requests
+from curl_cffi import requests
 
 from beanprice import source
 
@@ -39,7 +39,7 @@ def parse_response(response: requests.models.Response) -> Dict:
     """
     json = response.json(parse_float=Decimal)
     content = next(iter(json.values()))
-    if response.status_code != requests.codes.ok:
+    if response.status_code != 200:
         raise YahooError("Status {}: {}".format(response.status_code, content["error"]))
     if len(json) != 1:
         raise YahooError(
@@ -125,11 +125,14 @@ class Source(source.Source):
 
     def __init__(self):
         """Initialize a shared session with the required headers and cookies."""
-        self.session = requests.Session()
+        self.session = requests.Session(impersonate="chrome")
         self.session.headers.update(
             {
-                "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) "
-                "Gecko/20100101 Firefox/110.0"
+            "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) "
+                        "AppleWebKit/537.36 (KHTML, like Gecko) "
+                        "Chrome/121.0.0.0 Safari/537.36",
+            "Sec-Ch-Ua": '"Google Chrome";v="121", "Chromium";v="121", ";Not A Brand";v="99"',
+            "Sec-Ch-Ua-Platform": '"Linux"',
             }
         )
         # This populates the correct cookies in the session

--- a/beanprice/sources/yahoo.py
+++ b/beanprice/sources/yahoo.py
@@ -125,6 +125,10 @@ class Source(source.Source):
 
     def __init__(self):
         """Initialize a shared session with the required headers and cookies."""
+        
+        # Using curl_cffi's requests to impersonate a Chrome browser
+        # to avoid being blocked by Yahoo's bot detection.
+        # See issue https://github.com/beancount/beanprice/issues/106 for more details.
         self.session = requests.Session(impersonate="chrome")
         self.session.headers.update(
             {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     'beancount >= 3.0.0',
     'python-dateutil >= 2.6.0',
     'requests >= 2.0',
+    'curl_cffi>=0.6.5',
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 beancount>=3.0.0
 python-dateutil>=2.6.0
 requests>=2.0
+curl_cffi>=0.6.5


### PR DESCRIPTION
This PR is fixing the issue https://github.com/beancount/beanprice/issues/106

The issue is fixed by switching from the **requests** library to  **curl_cffi**. The latter is better able to impersonate a browser.

Also a small change to be able to run beanprice as  module is added https://github.com/beancount/beanprice/issues/107  