### PR TITLE
Do not install "experiments" in site-packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,8 @@ bean-price = 'beanprice.price:main'
 homepage = 'https://github.com/beancount/beanprice'
 issues = 'https://github.com/beancount/beanprice/issues'
 
-[tool.setuptools.packages]
-find = {}
+[tool.setuptools.packages.find]
+exclude = ["experiments*"]
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
Do not install `experiments` as a top-level module in site-packages.