### PR TITLE
option --precision is added

### DIFF
--- a/beanprice/price.py
+++ b/beanprice/price.py
@@ -687,7 +687,8 @@ def process_args() -> Tuple[
         entries: A list of all the parsed entries.
         dcontext: A context used to determine decimal precision when printing.
     """
-    parser = argparse.ArgumentParser(description=beanprice.__doc__.splitlines()[0])
+    parser = argparse.ArgumentParser(description=beanprice.__doc__.splitlines()[0],
+                                     formatter_class=argparse.RawTextHelpFormatter)
 
     # Input sources or filenames.
     parser.add_argument(
@@ -819,6 +820,20 @@ def process_args() -> Tuple[
         help=(
             "Don't actually fetch the prices, just print the list of the ones "
             "to be fetched."
+        ),
+    )
+
+    # Using str type here instead of bool to allow for future expansion of precision options.
+    parser.add_argument(
+        "-p",
+        "--precision",
+        type=str,
+        choices=['std', 'raw'],
+        default="std",
+        help=(
+            "Defines the approach to determine the precision with which  prices are printed (default: %(default)s).\n"
+            "std - standard beancount approach \n"
+            "raw - print the prices with the precision, received from the data source \n"
         ),
     )
 
@@ -977,6 +992,16 @@ def main():
             logging.info("Ignored to avoid clobber: %s %s", entry.date, entry.currency)
 
     # Print out the entries.
+
+    if args.precision == "raw":
+        dcontext = None
+
+    elif args.precision == "std":
+        pass
+
+    else:
+        raise ValueError(f"Invalid precision option: {args.precision}")
+
     printer.print_entries(price_entries, dcontext=dcontext)
 
 if __name__ == '__main__':


### PR DESCRIPTION
I believe this PR fixes issues https://github.com/beancount/beanprice/issues/65, https://github.com/beancount/beanprice/issues/92 and partially issue https://github.com/beancount/beanprice/issues/116.

It fixes it by adding option to effectively ignore `dcontext`, build by exploring ledger by introducing the following option

```
  -p {std,raw}, --precision {std,raw}
                        Defines the approach to determine the precision with which  prices are printed (default: std).
                        std - standard beancount approach
                        raw - print the prices with the precision, received from the data source
```
