### PR TITLE
Filter invalid time intervals to prevent duplicate Friday records

### DIFF
--- a/beanprice/price.py
+++ b/beanprice/price.py
@@ -436,6 +436,16 @@ def get_price_jobs_up_to_date(
             if not currency_map.get(key, None):
                 del lifetimes_map[key]
 
+    # Filter out invalid time intervals in lifetimes_map
+    lifetimes_map = {
+        currency_pair: [
+            (date_begin, date_end)
+            for date_begin, date_end in intervals
+            if date_begin < date_end
+        ]
+        for currency_pair, intervals in lifetimes_map.items()
+    }
+
     # Create price jobs based on fetch rate
     if update_rate == "daily":
         required_prices = lifetimes.required_daily_prices(


### PR DESCRIPTION
Remove intervals where begin >= end from lifetimes_map before generating price jobs. This addresses an edge case where closing positions on Fridays could result in duplicate price entries.

The issue stems from the callee's required_daily_prices() function which contains:

    for date_begin, date_end in intervals:
        if weekdays_only:
            diff_days = 4 - date_begin.weekday()
            if diff_days < 0:
                date += datetime.timedelta(days=diff_days)

When date_begin == date_end (e.g., when closing positions on Friday), this code would still process the interval and potentially create duplicate Friday records in the price requirements.

By filtering out these invalid intervals at the caller level, we prevent the problematic code path from being executed, ensuring only valid trading periods are processed for price data retrieval.