### PR TITLE
Added yahoo index support

### DIFF
--- a/beanprice/price.py
+++ b/beanprice/price.py
@@ -164,12 +164,17 @@ def parse_single_source(source: str) -> PriceSource:
     Raises:
       ValueError: If invalid.
     """
-    match = re.match(r"([a-zA-Z]+[a-zA-Z0-9\._]+)/(\^?)([a-zA-Z0-9:=_\-\.\(\)]+)$", source)
+    match = re.match(
+        r"([a-zA-Z]+[a-zA-Z0-9\._]+)/(\^*)([a-zA-Z0-9:=_\-\.\(\)\^]+)$", source
+    )
     if not match:
         raise ValueError('Invalid source name: "{}"'.format(source))
-    short_module_name, invert, symbol = match.groups()
+    short_module_name, carets, symbol = match.groups()
     module = import_source(short_module_name)
-    return PriceSource(module, symbol, bool(invert))
+    invert = len(carets) % 2 == 1
+    # Every pair of carets is replaced by a single caret in the ticker.
+    actual_symbol = ("^" * (len(carets) // 2)) + symbol
+    return PriceSource(module, actual_symbol, invert)
 
 
 def import_source(module_name: str):

--- a/beanprice/price_test.py
+++ b/beanprice/price_test.py
@@ -372,6 +372,18 @@ class TestParseSource(unittest.TestCase):
         psource = price.parse_single_source("yahoo/CNYUSD=X")
         self.assertEqual(PS(yahoo, "CNYUSD=X", False), psource)
 
+        psource = price.parse_single_source("yahoo/^CNYUSD=X")
+        self.assertEqual(PS(yahoo, "CNYUSD=X", True), psource)
+
+        psource = price.parse_single_source("yahoo/^^GSPC")
+        self.assertEqual(PS(yahoo, "^GSPC", False), psource)
+
+        psource = price.parse_single_source("yahoo/^^^GSPC")
+        self.assertEqual(PS(yahoo, "^GSPC", True), psource)
+
+        psource = price.parse_single_source("yahoo/TICK^ER")
+        self.assertEqual(PS(yahoo, "TICK^ER", False), psource)
+
         # Make sure that an invalid name at the tail doesn't succeed.
         with self.assertRaises(ValueError):
             psource = price.parse_single_source("yahoo/CNYUSD&X")


### PR DESCRIPTION
There is no way to add an index price from Yahoo Finance because index symbols start with the ^ character (for example, ^GSPC, https://finance.yahoo.com/quote/%5EGSPC/).

This fix allows using double carets (^^) to add such symbols.

```bash
bean-price -e 'USD:yahoo/^^GSPC'
```

Single caret (^) Indicates as inversion.