### PR TITLE
Stream price entries to stdout as they are fetched

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ To update prices up to the present day, run:
 bean-price --update ledger.beancount
 ```
 
+### Appending new prices to a file
+
+Output is streamed to stdout one entry per fetch, so it is safe to
+append directly — already-written entries survive an interrupted run:
+
+```shell
+bean-price --update ledger.beancount >> prices.beancount
+```
+
+After multiple runs, deduplicate and sort the file in-place:
+
+```shell
+sort -u -o prices.beancount prices.beancount
+```
+
 For more detailed guide for price fetching, read <https://beancount.github.io/docs/fetching_prices_in_beancount.html>.
 
 

--- a/beanprice/price.py
+++ b/beanprice/price.py
@@ -4,6 +4,7 @@ __copyright__ = "Copyright (C) 2015-2020  Martin Blais"
 __license__ = "GNU GPLv2"
 
 import argparse
+import codecs
 import collections
 import datetime
 import functools
@@ -961,31 +962,31 @@ def main():
             print(format_dated_price_str(dprice))
         return
 
-    # Fetch all the required prices, processing all the jobs.
-    executor = futures.ThreadPoolExecutor(max_workers=args.workers)
-    price_entries = filter(
-        None,
-        executor.map(
-            functools.partial(fetch_price, swap_inverted=args.swap_inverted), jobs
-        ),
-    )
-
-    # Sort them by currency, regardless of date (the dates should be close
-    # anyhow, and we tend to put them in chunks in the input files anyhow).
-    price_entries = sorted(price_entries, key=lambda e: e.currency)
-    if args.update:
-        # Sort additionally by date, to have an output consistent
-        # with single date bean-price output.
-        price_entries = sorted(price_entries, key=lambda e: e.date)
-
-    # Avoid clobber, remove redundant entries.
+    # Pre-build existing prices lookup for per-entry clobber filtering.
+    existing_prices = {}
     if not args.clobber:
-        price_entries, ignored_entries = filter_redundant_prices(price_entries, entries)
-        for entry in ignored_entries:
-            logging.info("Ignored to avoid clobber: %s %s", entry.date, entry.currency)
+        existing_prices = {
+            (entry.date, entry.currency): entry
+            for entry in entries
+            if isinstance(entry, data.Price)
+        }
 
-    # Print out the entries.
-    printer.print_entries(price_entries, dcontext=dcontext)
+    output = (
+        codecs.getwriter("utf-8")(sys.stdout.buffer)
+        if hasattr(sys.stdout, "buffer")
+        else sys.stdout
+    )
+    eprinter = printer.EntryPrinter(dcontext)
+
+    executor = futures.ThreadPoolExecutor(max_workers=args.workers)
+    fetch_fn = functools.partial(fetch_price, swap_inverted=args.swap_inverted)
+
+    for entry in filter(None, executor.map(fetch_fn, jobs)):
+        if not args.clobber and (entry.date, entry.currency) in existing_prices:
+            logging.info("Ignored to avoid clobber: %s %s", entry.date, entry.currency)
+            continue
+        output.write(eprinter(entry))
+        output.flush()
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Problem                                                
                                                                                                                                                                                                                                                                                                     
  The current implementation collects all fetched price entries in memory,                                                                                                                                                                                                                           
  sorts them, then prints everything at the end. If `bean-price` crashes or
  is interrupted mid-fetch (network error, OOM, SIGINT), all successfully                                                                                                                                                                                                                            
  fetched prices are lost and nothing is written to stdout.                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                     
  This is particularly painful when fetching hundreds of historical prices                                                                                                                                                                                                                           
  with `--update`, where a single failure discards all prior work.                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                     
  ## Solution                                               
                                                                                                                                                                                                                                                                                                     
  Replace the collect-sort-print pipeline with per-entry streaming: each                                                                                                                                                                                                                             
  price is written and flushed to stdout as soon as it is fetched.
                                                                                                                                                                                                                                                                                                     
  - `executor.map` is already lazy — it yields results in submission order                                                                                                                                                                                                                           
    as each future completes, so no architectural change is needed
  - Clobber filtering moves from a post-fetch batch pass                                                                                                                                                                                                                                             
    (`filter_redundant_prices`) to a per-entry dict lookup against a set                                                                                                                                                                                                                             
    built once upfront — same semantics, O(1) per entry                                                                                                                                                                                                                                              
  - Output encoding (`codecs.getwriter("utf-8")`) and formatting                                                                                                                                                                                                                                     
    (`EntryPrinter`) are identical to the previous `print_entries` path                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                     
  ## Trade-off                                              
                                                                                                                                                                                                                                                                                                     
  Output is no longer sorted by currency — entries are written in job                                                                                                                                                                                                                                
  submission order (which for `--update` is `(base, quote, date)`).
  beancount does not require price directives to be sorted, so this has no                                                                                                                                                                                                                           
  functional impact.                                          