### PR TITLE
Add East Money stock price source for Chinese market stocks

### DIFF
--- a/beanprice/sources/eastmoneystock.py
+++ b/beanprice/sources/eastmoneystock.py
@@ -1,0 +1,166 @@
+"""A source fetching stock prices from East Money (东方财富).
+
+East Money supports A-shares (Shanghai/Shenzhen) and Hong Kong stocks.
+This script fetches daily closing prices via the East Money kline API.
+
+The API, as far as I know, is undocumented.
+
+Ticker format:
+  - 6-digit code for A-shares: e.g. "600519" (Shanghai), "000858" (Shenzhen)
+  - 5-digit code for HK stocks: e.g. "00700"
+
+Prices are denoted in CNY for A-shares and HKD for HK stocks.
+Timezone information: the API returns GMT+8 data,
+    the function sets timezone to GMT+8 automatically.
+"""
+
+import datetime
+from decimal import Decimal
+
+import requests
+
+from beanprice import source
+
+
+TIMEZONE = datetime.timezone(datetime.timedelta(hours=+8), "Asia/Shanghai")
+
+# Market code mapping used by the East Money API.
+_MARKET_CODES = {
+    "SZ": "0",   # Shenzhen
+    "SH": "1",   # Shanghai
+    "HK": "116", # Hong Kong
+}
+
+_HEADERS = {
+    "Referer": "https://quote.eastmoney.com/",
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+        " (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36"
+    ),
+}
+
+
+class EastMoneyStockError(ValueError):
+    "An error from the East Money stock API."
+
+
+def _get_market_and_currency(ticker):
+    """Determine market code and quote currency from ticker.
+
+    Returns:
+        A tuple of (market_code, currency).
+    """
+    if ticker.isdigit() and len(ticker) == 6:
+        if ticker.startswith(("0", "1", "2", "3")):
+            return _MARKET_CODES["SZ"], "CNY"
+        if ticker.startswith(("5", "6")):
+            return _MARKET_CODES["SH"], "CNY"
+    if ticker.isdigit() and len(ticker) == 5:
+        return _MARKET_CODES["HK"], "HKD"
+    raise EastMoneyStockError(f"Unsupported ticker format: {ticker}")
+
+
+def _parse_kline_data(data):
+    """Parse kline data from API response.
+
+    Returns:
+        A list of (datetime, Decimal) tuples sorted by date ascending.
+    """
+    if not data or "data" not in data or not data["data"]:
+        return None
+    klines = data["data"].get("klines")
+    if not klines:
+        return None
+
+    result = []
+    for kline in klines:
+        parts = kline.split(",")
+        if len(parts) < 2:
+            continue
+        try:
+            date = datetime.datetime.strptime(
+                parts[0], "%Y-%m-%d"
+            ).replace(hour=15, tzinfo=TIMEZONE)
+            price = Decimal(parts[1])
+            result.append((date, price))
+        except (ValueError, IndexError):
+            continue
+
+    if not result:
+        return None
+    return sorted(result, key=lambda x: x[0])
+
+
+def get_price_series(ticker, time_begin, time_end):
+    """Fetch stock price series from the East Money API.
+
+    Args:
+        ticker: A string, the stock ticker code.
+        time_begin: Start of the date range (timezone-aware datetime).
+        time_end: End of the date range (timezone-aware datetime).
+    Returns:
+        A list of (datetime, Decimal) tuples sorted by date ascending.
+    """
+    base_url = "https://push2his.eastmoney.com/api/qt/stock/kline/get"
+
+    market_code, _ = _get_market_and_currency(ticker)
+    secid = f"{market_code}.{ticker}"
+    days = (time_end - time_begin).days + 1
+
+    params = {
+        "secid": secid,
+        "fields1": "f1,f2,f3,f4,f5,f6",
+        "fields2": "f51,f53",
+        "klt": "101",   # daily
+        "fqt": "0",     # unadjusted
+        "beg": time_begin.astimezone(TIMEZONE).strftime("%Y%m%d"),
+        "end": time_end.astimezone(TIMEZONE).strftime("%Y%m%d"),
+        "lmt": str(days),
+    }
+
+    response = requests.get(
+        base_url, params=params, headers=_HEADERS, timeout=30
+    )
+    if response.status_code != requests.codes.ok:
+        raise EastMoneyStockError(
+            f"Invalid response ({response.status_code}): {response.text}"
+        )
+
+    data = response.json()
+    prices = _parse_kline_data(data)
+    if prices is None:
+        raise EastMoneyStockError(
+            f"No price data for {ticker} between"
+            f" {time_begin.date()} and {time_end.date()}"
+        )
+    return prices
+
+
+class Source(source.Source):
+    "East Money stock price extractor."
+
+    def get_latest_price(self, ticker):
+        """See contract in beanprice.source.Source."""
+        _, currency = _get_market_and_currency(ticker)
+        end_time = datetime.datetime.now(TIMEZONE)
+        begin_time = end_time - datetime.timedelta(days=10)
+        prices = get_price_series(ticker, begin_time, end_time)
+        last = prices[-1]
+        return source.SourcePrice(last[1], last[0], currency)
+
+    def get_historical_price(self, ticker, time):
+        """See contract in beanprice.source.Source."""
+        _, currency = _get_market_and_currency(ticker)
+        begin_time = time - datetime.timedelta(days=10)
+        prices = get_price_series(ticker, begin_time, time)
+        last = prices[-1]
+        return source.SourcePrice(last[1], last[0], currency)
+
+    def get_prices_series(self, ticker, time_begin, time_end):
+        """See contract in beanprice.source.Source."""
+        _, currency = _get_market_and_currency(ticker)
+        result = [
+            source.SourcePrice(price, date, currency)
+            for date, price in get_price_series(ticker, time_begin, time_end)
+        ]
+        return sorted(result, key=lambda x: x.time)

--- a/beanprice/sources/eastmoneystock_test.py
+++ b/beanprice/sources/eastmoneystock_test.py
@@ -1,0 +1,165 @@
+import datetime
+import unittest
+from decimal import Decimal
+
+from unittest import mock
+
+from beanprice.sources import eastmoneystock
+from beanprice import source
+
+
+# ruff: noqa: E501
+
+# Sample API response for kline data (600519 - Kweichow Moutai).
+KLINE_RESPONSE = {
+    "rc": 0,
+    "rt": 6,
+    "svr": 123456,
+    "lt": 1,
+    "full": 0,
+    "data": {
+        "code": "600519",
+        "market": 1,
+        "name": "贵州茅台",
+        "decimal": 2,
+        "dktotal": 5,
+        "klines": [
+            "2024-01-02,1726.00",
+            "2024-01-03,1718.30",
+            "2024-01-04,1706.88",
+            "2024-01-05,1694.00",
+            "2024-01-08,1678.01",
+        ],
+    },
+}
+
+# Response with no klines data.
+EMPTY_RESPONSE = {
+    "rc": 0,
+    "rt": 6,
+    "data": {
+        "code": "600519",
+        "market": 1,
+        "klines": [],
+    },
+}
+
+
+def mock_response(json_data, status_code=200):
+    """Return a context manager to patch a JSON response."""
+    resp = mock.Mock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.text = str(json_data)
+    return mock.patch("requests.get", return_value=resp)
+
+
+class TestGetMarketAndCurrency(unittest.TestCase):
+    def test_shenzhen_stock(self):
+        code, currency = eastmoneystock._get_market_and_currency("000858")
+        self.assertEqual("0", code)
+        self.assertEqual("CNY", currency)
+
+    def test_shanghai_stock(self):
+        code, currency = eastmoneystock._get_market_and_currency("600519")
+        self.assertEqual("1", code)
+        self.assertEqual("CNY", currency)
+
+    def test_hk_stock(self):
+        code, currency = eastmoneystock._get_market_and_currency("00700")
+        self.assertEqual("116", code)
+        self.assertEqual("HKD", currency)
+
+    def test_unsupported_ticker(self):
+        with self.assertRaises(eastmoneystock.EastMoneyStockError):
+            eastmoneystock._get_market_and_currency("AAPL")
+
+
+class TestParseKlineData(unittest.TestCase):
+    def test_parse_valid_data(self):
+        result = eastmoneystock._parse_kline_data(KLINE_RESPONSE)
+        self.assertEqual(5, len(result))
+        self.assertEqual(
+            datetime.datetime(
+                2024, 1, 2, 15, 0, 0, tzinfo=eastmoneystock.TIMEZONE
+            ),
+            result[0][0],
+        )
+        self.assertEqual(Decimal("1726.00"), result[0][1])
+
+    def test_parse_empty_klines(self):
+        result = eastmoneystock._parse_kline_data(EMPTY_RESPONSE)
+        self.assertIsNone(result)
+
+    def test_parse_none_data(self):
+        result = eastmoneystock._parse_kline_data(None)
+        self.assertIsNone(result)
+
+
+class TestEastMoneyStock(unittest.TestCase):
+    def test_error_network(self):
+        with mock_response(None, 404):
+            with self.assertRaises(eastmoneystock.EastMoneyStockError):
+                eastmoneystock.get_price_series(
+                    "600519",
+                    datetime.datetime.now(eastmoneystock.TIMEZONE),
+                    datetime.datetime.now(eastmoneystock.TIMEZONE),
+                )
+
+    def test_get_latest_price(self):
+        with mock_response(KLINE_RESPONSE):
+            srcprice = eastmoneystock.Source().get_latest_price("600519")
+            self.assertIsInstance(srcprice, source.SourcePrice)
+            self.assertEqual(Decimal("1678.01"), srcprice.price)
+            self.assertEqual("CNY", srcprice.quote_currency)
+            self.assertEqual(
+                datetime.datetime(
+                    2024, 1, 8, 15, 0, 0,
+                    tzinfo=eastmoneystock.TIMEZONE,
+                ),
+                srcprice.time,
+            )
+
+    def test_get_historical_price(self):
+        with mock_response(KLINE_RESPONSE):
+            time = datetime.datetime(
+                2024, 1, 5, 0, 0, 0, tzinfo=eastmoneystock.TIMEZONE
+            )
+            srcprice = eastmoneystock.Source().get_historical_price(
+                "600519", time
+            )
+            self.assertIsInstance(srcprice, source.SourcePrice)
+            # Returns last price in the fetched range
+            self.assertEqual(Decimal("1678.01"), srcprice.price)
+            self.assertEqual("CNY", srcprice.quote_currency)
+
+    def test_get_prices_series(self):
+        with mock_response(KLINE_RESPONSE):
+            begin = datetime.datetime(
+                2024, 1, 1, 0, 0, 0, tzinfo=eastmoneystock.TIMEZONE
+            )
+            end = datetime.datetime(
+                2024, 1, 10, 0, 0, 0, tzinfo=eastmoneystock.TIMEZONE
+            )
+            prices = eastmoneystock.Source().get_prices_series(
+                "600519", begin, end
+            )
+            self.assertIsInstance(prices, list)
+            self.assertEqual(5, len(prices))
+            # Sorted ascending
+            self.assertEqual(Decimal("1726.00"), prices[0].price)
+            self.assertEqual(Decimal("1678.01"), prices[-1].price)
+            self.assertEqual("CNY", prices[0].quote_currency)
+
+    def test_empty_response_raises(self):
+        with mock_response(EMPTY_RESPONSE):
+            with self.assertRaises(eastmoneystock.EastMoneyStockError):
+                eastmoneystock.get_price_series(
+                    "600519",
+                    datetime.datetime.now(eastmoneystock.TIMEZONE),
+                    datetime.datetime.now(eastmoneystock.TIMEZONE),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `eastmoneystock` source for fetching Chinese stock prices from East Money (东方财富)
- Supports A-shares (Shanghai/Shenzhen, 6-digit tickers) and Hong Kong stocks (5-digit tickers)
- Returns prices in native currency: CNY for A-shares, HKD for HK stocks
- Uses the East Money kline API (daily closing prices, unadjusted)

## Usage

```
bean-price -e eastmoneystock/600519   # Kweichow Moutai (Shanghai)
bean-price -e eastmoneystock/000858   # Wuliangye (Shenzhen)
bean-price -e eastmoneystock/00700    # Tencent (Hong Kong)
```

## Test plan

- [x] Unit tests with mocked API responses (12 tests, all passing)
- [x] Verified against live API for Shanghai and Shenzhen stocks