### PR TITLE
feat: add --update-unpriced to fetch prices for unpriced currencies

### DIFF
--- a/beanprice/price.py
+++ b/beanprice/price.py
@@ -337,6 +337,41 @@ def get_price_jobs_at_date(
     return sorted(jobs)
 
 
+def get_price_jobs_unpriced(
+    entries: data.Entries,
+    quote: str,
+    date: Optional[datetime.date] = None,
+    undeclared_source: Optional[str] = None,
+) -> List[DatedPrice]:
+    """Get a list of prices to fetch for unpriced currencies.
+
+    These are currencies that have a balance but no price or cost history.
+
+    Args:
+      entries: A list of beancount entries.
+      quote: The quote currency to use.
+      date: A datetime.date instance.
+      undeclared_source: A string, the name of the default source module to use.
+    Returns:
+      A list of DatedPrice instances.
+    """
+    unpriced_bases = find_prices.find_unpriced_currencies(entries, date)
+    if not unpriced_bases:
+        return []
+
+    default_source_name = undeclared_source or DEFAULT_SOURCE
+    default_source = import_source(default_source_name)
+
+    jobs = []
+    for base in sorted(unpriced_bases):
+        # We only add it if it's not the same as the quote currency.
+        if base == quote:
+            continue
+        psources = [PriceSource(default_source, base, False)]
+        jobs.append(DatedPrice(base, quote, date, psources))
+    return jobs
+
+
 # TODO(blais): This could be modified to use the get_daily_prices() interface,
 # or perhaps to extend it to intervals, and let the price source decide for
 # itself how to implement fetching (e.g., use a single call + filter, or use
@@ -763,6 +798,18 @@ def process_args() -> Tuple[
     )
 
     parser.add_argument(
+        "--update-unpriced",
+        nargs="?",
+        const=True,
+        metavar="CURRENCY",
+        help=(
+            "Fetch latest prices for currencies that have a balance but no "
+            "price or cost history. The optional argument is the quote currency to "
+            "use for these prices (defaults to USD or first operating_currency)."
+        ),
+    )
+
+    parser.add_argument(
         "-i",
         "--inactive",
         action="store_true",
@@ -884,6 +931,7 @@ def process_args() -> Tuple[
     jobs = []
     all_entries = []
     dcontext = None
+    options_map: Dict[str, Any] = {}
     if args.expressions:
         # Interpret the arguments as price sources.
         for source_str in args.sources:
@@ -948,6 +996,21 @@ def process_args() -> Tuple[
                     get_price_jobs_at_date(entries, date, args.inactive, args.undeclared)
                 )
                 all_entries.extend(entries)
+
+    if all_entries and args.update_unpriced:
+        quote = (
+            args.update_unpriced
+            if isinstance(args.update_unpriced, str)
+            else (options_map.get("operating_currency", ["USD"]) or ["USD"])[0]
+        )
+        unpriced_jobs = get_price_jobs_unpriced(
+            all_entries, quote, args.date, args.undeclared
+        )
+        # Avoid duplicates
+        existing_job_keys = {(j.base, j.quote, j.date) for j in jobs}
+        for j in unpriced_jobs:
+            if (j.base, j.quote, j.date) not in existing_job_keys:
+                jobs.append(j)
 
     return args, jobs, data.sorted(all_entries), dcontext
 

--- a/beanprice/price.py
+++ b/beanprice/price.py
@@ -799,13 +799,18 @@ def process_args() -> Tuple[
 
     parser.add_argument(
         "--update-unpriced",
-        nargs="?",
-        const=True,
-        metavar="CURRENCY",
+        action="store_true",
         help=(
             "Fetch latest prices for currencies that have a balance but no "
-            "price or cost history. The optional argument is the quote currency to "
-            "use for these prices (defaults to USD or first operating_currency)."
+            "price or cost history."
+        ),
+    )
+
+    parser.add_argument(
+        "--unpriced-quote",
+        metavar="CURRENCY",
+        help=(
+            "The quote currency to use for unpriced prices (defaults to USD or first operating_currency)."
         ),
     )
 
@@ -999,8 +1004,8 @@ def process_args() -> Tuple[
 
     if all_entries and args.update_unpriced:
         quote = (
-            args.update_unpriced
-            if isinstance(args.update_unpriced, str)
+            args.unpriced_quote
+            if args.unpriced_quote
             else (options_map.get("operating_currency", ["USD"]) or ["USD"])[0]
         )
         unpriced_jobs = get_price_jobs_unpriced(

--- a/beanprice/price.py
+++ b/beanprice/price.py
@@ -1003,11 +1003,17 @@ def process_args() -> Tuple[
                 all_entries.extend(entries)
 
     if all_entries and args.update_unpriced:
-        quote = (
-            args.unpriced_quote
-            if args.unpriced_quote
-            else (options_map.get("operating_currency", ["USD"]) or ["USD"])[0]
-        )
+        if args.unpriced_quote:
+            quote = args.unpriced_quote
+        else:
+            operating_currencies = options_map.get("operating_currency", [])
+            if not operating_currencies:
+                parser.error(
+                    "--update-unpriced requires a quote currency. "
+                    "Please specify --unpriced-quote or define 'operating_currency' in your ledger."
+                )
+            quote = operating_currencies[0]
+
         unpriced_jobs = get_price_jobs_unpriced(
             all_entries, quote, args.date, args.undeclared
         )

--- a/beanprice/price_test.py
+++ b/beanprice/price_test.py
@@ -624,6 +624,27 @@ class TestFilters(unittest.TestCase):
             {(job.base, job.quote, job.date) for job in jobs},
         )
 
+    @loader.load_doc()
+    def test_get_price_jobs_unpriced(self, entries, _, __):
+        """
+        2000-01-10 open Assets:US:Invest:QQQ
+        2000-01-10 open Assets:US:Invest:VEA
+        2000-01-10 open Assets:Cash
+        2000-01-10 open Equity:OpeningBalances
+
+        2021-01-01 commodity QQQ
+          price: "USD:yahoo/NASDAQ:QQQ"
+
+        2021-01-04 *
+          Assets:US:Invest:QQQ             100 QQQ {86.23 USD}
+          Assets:US:Invest:VEA             200 VEA
+          Assets:Cash                    1000 USD
+          Equity:OpeningBalances
+        """
+        # VEA is held but has no price or cost history (it's at balance but no cost).
+        jobs = price.get_price_jobs_unpriced(entries, "USD", None, "yahoo")
+        self.assertEqual({("VEA", "USD")}, {(job.base, job.quote) for job in jobs})
+
 
 class TestFromFile(unittest.TestCase):
     @loader.load_doc()


### PR DESCRIPTION
This PR adds a new CLI argument `--update-unpriced` to `bean-price` which fetches prices for currencies that have a balance in the ledger but no price or cost history.

- Added `get_price_jobs_unpriced` to identify currencies with balance but no price/cost history.
- Added `--update-unpriced` CLI argument to `bean-price`.
- Added `--unpriced-quote` CLI argument to specify the target currency (optional if `operating_currency` is defined in the ledger).
- The tool now correctly fails if no quote currency can be determined (no `--unpriced-quote` and no `operating_currency`).
- Integrated unpriced job discovery into `process_args`.
- Added test case in `price_test.py`.

Requires `beancount.ops.find_prices.find_unpriced_currencies` (added in recent Beancount versions).